### PR TITLE
Allow properties to be undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ export default class ExpoMixpanelAnalytics {
   _pushEvent(event) {
     let data = {
       event: event.name,
-      properties: event.props
+      properties: event.props || {}
     };
     if (this.userId) {
       data.properties.distinct_id = this.userId;


### PR DESCRIPTION
When calling track without options, `event.props` are not assumed to be an empty object, which throws an error for trying to access sub values of an undefined one.